### PR TITLE
revert: Revert "fix: Set Next.js output directory to 'dist'"

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  distDir: 'dist',
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
This reverts the commit that changed the Next.js build output directory to 'dist'.

This change is being reverted because, while it fixed the Vercel build error, it caused a 404 error on the deployed homepage. The new approach is to keep the default Next.js build directory (`.next`) and instruct the user to update their Vercel project settings instead.